### PR TITLE
Add requirements to get to door 1 in Landing Site

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -473,6 +473,29 @@
           "from": 5,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    {"canShineCharge": {
+                      "usedTiles": 33,
+                      "shinesparkFrames": 40,
+                      "openEnd": 2
+                    }}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": ["h_canDestroyBombWalls"]
+                    }
+                  ]
+                }
+              ],
+              "note": "This link is only for sparking. All other strats should go 5 -> 7 -> 1."
+            },
+            {
               "id": 2,
               "strats": [
                 {
@@ -578,7 +601,13 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [],
+                  "requires": [
+                    {"or": [
+                      "canWalljump",
+                      "h_canFly",
+                      "HiJump"
+                    ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",


### PR DESCRIPTION
The existing logic from location 7 to 1 only requires h_canDestroyBombWalls, but it should require abilities to get up to those blocks. A shinespark can also be used to get from 5 to 1 bypassing 7 (this uses less energy than shinesparking from 4 to 1, but only breaks the first set of blocks).