### PR TITLE
Update h_speedDash override for new Spark Booster behavior

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1759,11 +1759,11 @@
         {
           "name": "h_speedDash",
           "requires": [
-            "h_anyBoosterItem",
+            "h_blueBoosterItem",
             "canDash"
           ],
           "devNote": [
-            "This for using Speed Booster (or Blue Booster or Spark Booster) to gain high run speed, for cases that do not involve a jump nor blue speed."
+            "This for using Speed Booster (or Blue Booster) to gain high run speed, for cases that do not involve a jump nor blue speed."
           ]
         },
         {


### PR DESCRIPTION
We are changing Spark Booster to cap dash speed at $2.0, and updating the `h_speedDash` override is the main logical adjustment needed to take that into account.